### PR TITLE
enable ta/ma all 1s

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 go: main
-	qemu-riscv64 -cpu rv64,v=true,zba=true,vlen=128 ./main
+	qemu-riscv64 -cpu rv64,v=true,zba=true,vlen=128,rvv_ta_all_1s=on,rvv_ma_all_1s=on ./main
 
 main: main.c vec.S makefile
 	riscv64-unknown-elf-gcc -O main.c vec.S -o main -march=rv64gcv_zba -lm


### PR DESCRIPTION
I think that enabling these options by default, especially for beginners, is a good idea.
Otherwise it's likely that people write code that only works under tu/mu and don't realize it.